### PR TITLE
Defer pack loading until upload service ready

### DIFF
--- a/src/main/kotlin/me/pectics/paper/plugin/permpacks/Options.kt
+++ b/src/main/kotlin/me/pectics/paper/plugin/permpacks/Options.kt
@@ -53,11 +53,9 @@ internal class Options private constructor(private val plugin: PermPacks) {
     init {
         // Extract and load configs
         wrappers.forEach(FileConfigWrapper::load)
-        // Read packs
-        readPacks()
     }
 
-    private fun readPacks() {
+    fun loadPacks() {
         _packs.clear()
         FileMetaRepository.clear()
         val packsConfig = packsWrapper.config
@@ -170,9 +168,11 @@ internal class Options private constructor(private val plugin: PermPacks) {
             instance = Options(plugin)
         }
 
+        fun loadPacks() = instance.loadPacks()
+
         fun reload() {
             instance.wrappers.forEach(FileConfigWrapper::reload)
-            instance.readPacks()
+            instance.loadPacks()
         }
 
     }

--- a/src/main/kotlin/me/pectics/paper/plugin/permpacks/PermPacks.kt
+++ b/src/main/kotlin/me/pectics/paper/plugin/permpacks/PermPacks.kt
@@ -31,6 +31,8 @@ class PermPacks: JavaPlugin() {
                 ?: logger.warning("File upload service is not specified.")
         }
 
+        Options.loadPacks()
+
         // Hook ProtocolLib if available
         server.pluginManager.getPlugin("ProtocolLib")
             ?.let {


### PR DESCRIPTION
## Summary
- expose `Options.loadPacks` so packs are only parsed when invoked and reuse it for reloads
- call `Options.loadPacks()` after upload service initialization to rebuild pack caches with the proper service state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d02aef58fc832d802f6885780f0202