### PR TITLE
Initialize file meta repository before options

### DIFF
--- a/src/main/kotlin/me/pectics/paper/plugin/permpacks/PermPacks.kt
+++ b/src/main/kotlin/me/pectics/paper/plugin/permpacks/PermPacks.kt
@@ -13,8 +13,8 @@ class PermPacks: JavaPlugin() {
 
     override fun onEnable() {
         BinaryCache.initialize(this)
-        Options.initialize(this)
         FileMetaRepository.initialize(this)
+        Options.initialize(this)
 
         // Initialize upload service if enabled
         if (Options.fileUploadEnabled) {


### PR DESCRIPTION
## Summary
- ensure FileMetaRepository initializes before Options in PermPacks.onEnable so repository is ready for pack loading

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d02b717f58832db5bab3133f041f04