### PR TITLE
Use reified serializer when caching values

### DIFF
--- a/src/main/kotlin/me/pectics/paper/plugin/permpacks/BinaryCache.kt
+++ b/src/main/kotlin/me/pectics/paper/plugin/permpacks/BinaryCache.kt
@@ -112,7 +112,7 @@ internal class BinaryCache private constructor(plugin: PermPacks) {
         inline operator fun <reified T> get(key: String): T? =
             instance.map[key]?.let(Json::decodeFromString)
 
-        operator fun set(key: String, value: Any) {
+        inline operator fun <reified T> set(key: String, value: T) {
             instance.map[key] = Json.encodeToString(value)
             instance.scheduleWrite()
         }


### PR DESCRIPTION
## Summary
- make BinaryCache#set inline with a reified type parameter so Json uses the concrete serializer for cached values

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d02f12aaa4832d9bd2d281a7b40589