### PR TITLE
Allow upload services to validate cached URLs

### DIFF
--- a/src/main/kotlin/me/pectics/paper/plugin/permpacks/Options.kt
+++ b/src/main/kotlin/me/pectics/paper/plugin/permpacks/Options.kt
@@ -57,6 +57,7 @@ internal class Options private constructor(private val plugin: PermPacks) {
 
     fun loadPacks() {
         _packs.clear()
+        UploadService.clearCache()
         FileMetaRepository.clear()
         val packsConfig = packsWrapper.config
 

--- a/src/main/kotlin/me/pectics/paper/plugin/permpacks/upload/selfhost/SelfHostService.kt
+++ b/src/main/kotlin/me/pectics/paper/plugin/permpacks/upload/selfhost/SelfHostService.kt
@@ -1,8 +1,10 @@
 package me.pectics.paper.plugin.permpacks.upload.selfhost
 
 import com.sun.net.httpserver.HttpServer
+import me.pectics.paper.plugin.permpacks.data.FilePackItem
 import me.pectics.paper.plugin.permpacks.upload.FileMetaRepository
 import me.pectics.paper.plugin.permpacks.upload.UploadService
+import me.pectics.paper.plugin.permpacks.util.SerializableURL
 import me.pectics.paper.plugin.permpacks.util.cap
 import me.pectics.paper.plugin.permpacks.util.sha1
 import me.pectics.paper.plugin.permpacks.util.validate
@@ -53,6 +55,10 @@ object SelfHostService: UploadService {
             FileMetaRepository.push(file)
         val url = urlFormat.format(FileMetaRepository[hash]!!.repoFile.name)
         return URI.create(url).toURL()
+    }
+
+    override fun isCachedUrlValid(item: FilePackItem, cached: SerializableURL): Boolean {
+        return item.hash in FileMetaRepository
     }
 
 }


### PR DESCRIPTION
## Summary
- add an UploadService.isCachedUrlValid hook so implementations can decide when cached URLs should be reused
- have SelfHostService require FileMetaRepository entries before accepting cached URLs, ensuring metadata is restored after cache clears

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d02f13eef4832d92c57e39ed302c28